### PR TITLE
Enhancement: Use new getPopulatedFieldsAsMap() method

### DIFF
--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -117,11 +117,8 @@ public class DMLManager {
 	} 
 	
 	private static Map<String,Object> getFieldMapFromExistingSObject(SObject obj){
-		// Get actual fields present in object.  This serialization technique removes implicit nulls.
-		String s = JSON.serialize(obj);
-		Map<String,Object> fieldsMap = (Map<String,Object>) JSON.deserializeUntyped(s);
-		fieldsMap.remove('attributes');
-		return fieldsMap;		
+		// Get actual fields present in object.  The getPopulatedFieldsAsMap method removes implicit nulls.
+		return obj.getPopulatedFieldsAsMap();
 	}
 	
 	private static void checkCreateAction(SObject obj){

--- a/src/classes/DMLManager.cls-meta.xml
+++ b/src/classes/DMLManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>30.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/DMLManager.cls-meta.xml
+++ b/src/classes/DMLManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Test_DMLManager.cls-meta.xml
+++ b/src/classes/Test_DMLManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>30.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Test_DMLManager.cls-meta.xml
+++ b/src/classes/Test_DMLManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -4,5 +4,5 @@
         <members>*</members>
         <name>ApexClass</name>
     </types>
-    <version>37.0</version>
+    <version>39.0</version>
 </Package>

--- a/src/package.xml
+++ b/src/package.xml
@@ -4,5 +4,5 @@
         <members>*</members>
         <name>ApexClass</name>
     </types>
-    <version>29.0</version>
+    <version>37.0</version>
 </Package>


### PR DESCRIPTION
With Summer '16 Salesforce has added a native method to the SObject class that makes the serialization/deserialization technique used by DMLManager.getFieldMapFromExistingSObject no longer necessary.

I haven't done any benchmarking, but I assume the new method should improve performance as well since serializing SObjects and deserializing strings can be costly wrt CPU time.

Thanks for building and open-sourcing this repository; I recently had a managed package rejected by Salesforce's security review team due to their now stricter requirements for CRUD/FLS enforcement so it was nice to come across this tool. Would it be alright if I pulled it into an [open-sourced dev framework I've been building](https://github.com/scottbcovert/Centralized-Salesforce-Dev-Framework)?
