### PR TITLE
Enable the injection of customized DML operations

### DIFF
--- a/scripts/soql/account.soql
+++ b/scripts/soql/account.soql
@@ -1,6 +1,0 @@
-// Use .soql files to store SOQL queries.
-// You can execute queries in VS Code by selecting the
-//     query text and running the command:
-//     SFDX: Execute SOQL Query with Currently Selected Text
-
-SELECT Id, Name FROM Account

--- a/scripts/soql/account.soql
+++ b/scripts/soql/account.soql
@@ -1,0 +1,6 @@
+// Use .soql files to store SOQL queries.
+// You can execute queries in VS Code by selecting the
+//     query text and running the command:
+//     SFDX: Execute SOQL Query with Currently Selected Text
+
+SELECT Id, Name FROM Account

--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -45,16 +45,16 @@ public inherited sharing class DMLManager {
 	
 	// Pass-thru methods to desired DML operations as configured by consumer.
 	// Use these sparingly, and only with good reason, since the DML operations are not CRUD/FLS safe
-	public static void insertAsSystem(sObject obj){ dmlOperations.insertOperation(new List<SObject> {obj}); }
-	public static void updateAsSystem(sObject obj){ dmlOperations.updateOperation(new List<SObject> {obj}); }
-	public static void upsertAsSystem(sObject obj){ dmlOperations.upsertOperation(new List<SObject> {obj}); }
-	public static void deleteAsSystem(sObject obj){ dmlOperations.deleteOperation(new List<SObject> {obj}); }
-	public static void mergeAsSystem(SObject masterObj, SObject mergeObj){ dmlOperations.mergeOperation(masterObj, new List<SObject> {mergeObj}); }
-	public static void insertAsSystem(List<SObject> objList){ dmlOperations.insertOperation(objList); }
-	public static void updateAsSystem(List<SObject> objList){ dmlOperations.updateOperation(objList); }
-	public static void upsertAsSystem(List<SObject> objList){ dmlOperations.upsertOperation(objList); }
-	public static void deleteAsSystem(List<SObject> objList){ dmlOperations.deleteOperation(objList); }
-	public static void mergeAsSystem(SObject masterObj, List<SObject> mergeList){ dmlOperations.mergeOperation(masterObj, mergeList); }
+	public static void insertAsSystem(sObject obj){ dmlOperations.dmlInsert(new List<SObject> {obj}); }
+	public static void updateAsSystem(sObject obj){ dmlOperations.dmlUpdate(new List<SObject> {obj}); }
+	public static void upsertAsSystem(sObject obj){ dmlOperations.dmlUpsert(new List<SObject> {obj}); }
+	public static void deleteAsSystem(sObject obj){ dmlOperations.dmlDelete(new List<SObject> {obj}); }
+	public static void mergeAsSystem(SObject masterObj, SObject mergeObj){ dmlOperations.dmlMerge(masterObj, new List<SObject> {mergeObj}); }
+	public static void insertAsSystem(List<SObject> objList){ dmlOperations.dmlInsert(objList); }
+	public static void updateAsSystem(List<SObject> objList){ dmlOperations.dmlUpdate(objList); }
+	public static void upsertAsSystem(List<SObject> objList){ dmlOperations.dmlUpsert(objList); }
+	public static void deleteAsSystem(List<SObject> objList){ dmlOperations.dmlDelete(objList); }
+	public static void mergeAsSystem(SObject masterObj, List<SObject> mergeList){ dmlOperations.dmlMerge(masterObj, mergeList); }
 	
 	// Custom Exception Classes
 	public virtual class DMLManagerException extends Exception{
@@ -159,7 +159,7 @@ public inherited sharing class DMLManager {
 		}
 		
 		if(existingRecord == null){
-		    throw new DMLManagerException('DMLManager ERROR:  An existing record could not be found for object with Id = ' + obj.Id);
+			throw new DMLManagerException('DMLManager ERROR:  An existing record could not be found for object with Id = ' + obj.Id);
 		}
 
 		Map<String,Object> fieldsMap = getFieldMapFromExistingSObject(obj);
@@ -279,38 +279,44 @@ public inherited sharing class DMLManager {
 	// 1. Create an Apex class implementing the DMLManager.IDML interface and having the desired functionality
 	// 2. Set DMLManager.dmlOperations property to an instance of the Apex class
 	// 3. Execute the appropriate *AsUser or *AsSystem methods as usual
-	public static IDML dmlOperations = new DefaultDmlOperations();
+	private static IDML dmlOperations = new SimpleDML();
 
-	// "Operation" suffix needed since the root DML operation name is an Apex keyword.
-	public interface IDML {
-		List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete);
-		List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert);
-		List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords);
-		List<Database.SaveResult> updateOperation(List<SObject> recordsToInsert);
-		List<Database.UpsertResult> upsertOperation(List<SObject> recordsToInsert);
+	public static void setDmlImplementation(IDML dmlImplementation) {
+		dmlOperations = dmlImplementation;
 	}
 
-	public class DefaultDmlOperations
+	// "Operation" suffix needed since the root DML operation name is an Apex keyword.
+	public interface IDML
+	{
+		void dmlInsert(List<SObject> objList);
+		void dmlUpdate(List<SObject> objList);
+		void dmlDelete(List<SObject> objList);
+		void dmlMerge(SObject masterRecord, List<SObject> objList);
+		void dmlUpsert(List<SObject> objList);
+	}
+
+	public virtual class SimpleDML
 		implements IDML
 	{
-		public List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete) {
-			return Database.delete(recordsToDelete);
+		public virtual void dmlInsert(List<SObject> objList)
+		{
+			insert objList;
 		}
-
-		public List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert) {
-			return Database.insert(recordsToInsert);
+		public virtual void dmlUpdate(List<SObject> objList)
+		{
+			update objList;
 		}
-
-		public List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords) {
-			return Database.merge(masterRecord, duplicateRecords);
+		public virtual void dmlDelete(List<SObject> objList)
+		{
+			delete objList;
 		}
-
-		public List<Database.SaveResult> updateOperation(List<SObject> recordsToUpdate) {
-			return Database.update(recordsToUpdate);
+		public virtual void dmlMerge(SObject masterRecord, List<SObject> objList)
+		{
+			Database.merge(masterRecord, objList);
 		}
-
-		public List<Database.UpsertResult> upsertOperation(List<SObject> recordsToUpsert) {
-			return Database.upsert(recordsToUpsert);
+		public virtual void dmlUpsert(List<SObject> objList)
+		{
+			upsert objList;
 		}
 	}
 }

--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -282,7 +282,7 @@ public inherited sharing class DMLManager {
 	// 3. Execute the appropriate *AsUser or *AsSystem methods as usual
 	private static IDML dmlOperations = new SimpleDML();
 
-	public static void setDmlImplementation(IDML dmlImplementation) {
+	public static void setDMLImplementation(IDML dmlImplementation) {
 		dmlOperations = dmlImplementation;
 	}
 
@@ -296,7 +296,7 @@ public inherited sharing class DMLManager {
 		void dmlUpsert(List<SObject> objList);
 	}
 
-	public virtual class SimpleDML
+	public inherited sharing virtual class SimpleDML
 		implements IDML
 	{
 		public virtual void dmlInsert(List<SObject> objList)

--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -43,18 +43,18 @@ public inherited sharing class DMLManager {
 	public static void deleteAsUser(List<SObject> objList){performDMLOperation(objList,Operation.OP_DELETE);}
 	public static void mergeAsUser(SObject masterObj, List<SObject> mergeList){ performDMLMergeOperation(masterObj, mergeList);}
 	
-	// Pass-thru methods to raw DML operations. 
+	// Pass-thru methods to desired DML operations as configured by consumer.
 	// Use these sparingly, and only with good reason, since the DML operations are not CRUD/FLS safe
-	public static void insertAsSystem(sObject obj){ insert obj; }
-	public static void updateAsSystem(sObject obj){ update obj; }
-	public static void upsertAsSystem(sObject obj){ upsert obj; }
-	public static void deleteAsSystem(sObject obj){ delete obj; }
-	public static void mergeAsSystem(SObject masterObj, SObject mergeObj){ Database.merge(masterObj, mergeObj); }
-	public static void insertAsSystem(List<SObject> objList){ insert objList; }
-	public static void updateAsSystem(List<SObject> objList){ update objList; }
-	public static void upsertAsSystem(List<SObject> objList){ upsert objList; }
-	public static void deleteAsSystem(List<SObject> objList){ delete objList; }
-	public static void mergeAsSystem(SObject masterObj, List<SObject> mergeList){ Database.merge(masterObj, mergeList); }
+	public static void insertAsSystem(sObject obj){ dmlOperations.insertOperation(new List<SObject> {obj}); }
+	public static void updateAsSystem(sObject obj){ dmlOperations.updateOperation(new List<SObject> {obj}); }
+	public static void upsertAsSystem(sObject obj){ dmlOperations.upsertOperation(new List<SObject> {obj}); }
+	public static void deleteAsSystem(sObject obj){ dmlOperations.deleteOperation(new List<SObject> {obj}); }
+	public static void mergeAsSystem(SObject masterObj, SObject mergeObj){ dmlOperations.mergeOperation(masterObj, new List<SObject> {mergeObj}); }
+	public static void insertAsSystem(List<SObject> objList){ dmlOperations.insertOperation(objList); }
+	public static void updateAsSystem(List<SObject> objList){ dmlOperations.updateOperation(objList); }
+	public static void upsertAsSystem(List<SObject> objList){ dmlOperations.upsertOperation(objList); }
+	public static void deleteAsSystem(List<SObject> objList){ dmlOperations.deleteOperation(objList); }
+	public static void mergeAsSystem(SObject masterObj, List<SObject> mergeList){ dmlOperations.mergeOperation(masterObj, mergeList); }
 	
 	// Custom Exception Classes
 	public virtual class DMLManagerException extends Exception{
@@ -102,11 +102,11 @@ public inherited sharing class DMLManager {
 				}
 			}
 		}
-		// If no errors have been thrown to this point, execute the dml operation.
-		if(dmlOperation == Operation.OP_INSERT){insert objList;} 
-			else if (dmlOperation == Operation.OP_UPDATE){update objList;} 
-				else if (dmlOperation == Operation.OP_UPSERT){upsertCollection(objList);}
-					else if (dmlOperation == Operation.OP_DELETE){delete objList;}
+		// If no errors have been thrown to this point, execute the dml operation via pass-through methods.
+		if(dmlOperation == Operation.OP_INSERT){insertAsSystem(objList);} 
+			else if (dmlOperation == Operation.OP_UPDATE){updateAsSystem(objList);} 
+				else if (dmlOperation == Operation.OP_UPSERT){upsertAsSystem(objList);}
+					else if (dmlOperation == Operation.OP_DELETE){deleteAsSystem(objList);}
 	}
 	
 	/**
@@ -126,19 +126,8 @@ public inherited sharing class DMLManager {
 		checkCRUDPermission(new Set<SObjectType>{mergeList[0].getSObjectType()},Operation.OP_DELETE);
 		
 		// If no errors have been thrown to this point, execute the merge operation.
-		Database.merge(masterObj, mergeList);
+		mergeAsSystem(masterObj, mergeList);
 	}
-	
-	private static void upsertCollection(List<SObject> objList){
-		// This is to deal with a call to upsertAsUser with a singular object.
-		// Since we wrap that into a List<SObject> (which can't be passed into an upsert)
-		// we unpack it and upsert the object individually.
-		if(objList.size() == 1){
-			upsert objList.get(0);
-		} else {
-			upsert objList;
-		}
-	} 
 	
 	private static Map<String,Object> getFieldMapFromExistingSObject(SObject obj){
 		// Get actual fields present in object.  The getPopulatedFieldsAsMap method removes implicit nulls.
@@ -284,6 +273,44 @@ public inherited sharing class DMLManager {
 			}
 			operationRestrictedFields.put(obj.getSObjectType(),restrictedFields);
 		}
-	}	
+	}
 
+	// If the consumer desires a customized DML experience, including mock SObject unit testing:
+	// 1. Create an Apex class implementing the DMLManager.IDML interface and having the desired functionality
+	// 2. Set DMLManager.dmlOperations property to an instance of the Apex class
+	// 3. Execute the appropriate *AsUser or *AsSystem methods as usual
+	public static IDML dmlOperations = new DefaultDmlOperations();
+
+	// "Operation" suffix needed since the root DML operation name is an Apex keyword.
+	public interface IDML {
+		List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete);
+		List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert);
+		List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords);
+		List<Database.SaveResult> updateOperation(List<SObject> recordsToInsert);
+		List<Database.UpsertResult> upsertOperation(List<SObject> recordsToInsert);
+	}
+
+	public class DefaultDmlOperations
+		implements IDML
+	{
+		public List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete) {
+			return Database.delete(recordsToDelete);
+		}
+
+		public List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert) {
+			return Database.insert(recordsToInsert);
+		}
+
+		public List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords) {
+			return Database.merge(masterRecord, duplicateRecords);
+		}
+
+		public List<Database.SaveResult> updateOperation(List<SObject> recordsToUpdate) {
+			return Database.update(recordsToUpdate);
+		}
+
+		public List<Database.UpsertResult> upsertOperation(List<SObject> recordsToUpsert) {
+			return Database.upsert(recordsToUpsert);
+		}
+	}
 }

--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -276,7 +276,8 @@ public inherited sharing class DMLManager {
 	}
 
 	// If the consumer desires a customized DML experience, including mock SObject unit testing:
-	// 1. Create an Apex class implementing the DMLManager.IDML interface and having the desired functionality
+	// 1. Create an Apex class that either extends SimpleDML and overrides the method(s) you wish to customize 
+	//    or create a new Apex class that implements the IDML interface
 	// 2. Set DMLManager.dmlOperations property to an instance of the Apex class
 	// 3. Execute the appropriate *AsUser or *AsSystem methods as usual
 	private static IDML dmlOperations = new SimpleDML();

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -522,7 +522,7 @@ private class Test_DMLManager {
 	}
 
 	@IsTest
-	static void dmlOperation_When_CustomInertDmlOperationsAreSpecified_Expect_NoChangesWithinServer() {
+	static void dmlOperation_When_CustomInertDMLOperationsAreSpecified_Expect_NoChangesWithinServer() {
 
 		Contact ctc = new Contact();
 		ctc.FirstName = 'Jeremiah';
@@ -539,35 +539,35 @@ private class Test_DMLManager {
 		ctc.LastName = 'Long';
 
 		// Injecting the inert DML class
-		DMLManager.setDmlImplementation(new InertDML());
+		DMLManager.setDMLImplementation(new InertDML());
 
 		DMLManager.updateAsUser(ctc);
 
-		// Since the InertDml does nothing, the DMLManager operation respectively does nothing,
+		// Since the InertDML does nothing, the DMLManager operation respectively does nothing,
 		// therefore the Contact is NOT saved within Salesforce.
 		actualContactList = [select LastName from Contact where Id= :ctc.Id];
 		System.assertEquals(expectedLastName, actualContactList.get(0).LastName, 'The Contact should retain the original data.');
 	}
 
-	private class InertDml extends DMLManager.SimpleDML {
+	private class InertDML extends DMLManager.SimpleDML {
 		public override void dmlDelete(List<SObject> recordsToDelete) {
-			// Do nothing.
+			return;
 		}
 
 		public override void dmlInsert(List<SObject> recordsToInsert) {
-			// Do nothing.
+			return;
 		}
 
 		public override void dmlMerge(sObject masterRecord, List<SObject> duplicateRecords) {
-			// Do nothing.
+			return;
 		}
 
 		public override void dmlUpdate(List<SObject> recordsToUpdate) {
-			// Do nothing.
+			return;
 		}
 
 		public override void dmlUpsert(List<SObject> recordsToUpsert) {
-			// Do nothing.
+			return;
 		}
 	}
 

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -500,16 +500,26 @@ private class Test_DMLManager {
 		ctc.FirstName = 'Jeremiah';
 		ctc.LastName = 'Matthews';
 
-		DMLManager.dmlOperations = new InertDmlOperations();
-
+		// ------ First let's clearly assert the default DML operation is working ------
 		DMLManager.insertAsUser(ctc);
-
+		
 		String query = 'select Id from Contact where FirstName=\'' + ctc.FirstName + '\' and LastName=\'' + ctc.LastName + '\'';
 		List<Contact> actualContactList = Database.query(query);
+		System.assertEquals(1, actualContactList.size(), 'The Salesforce database should contain the new Contact.');
+
+		// ------ Now let's test the DML Operation injection ------
+		ctc.LastName = 'Long';
+
+		// Injecting the inert DML class
+		DMLManager.dmlOperations = new InertDmlOperations();
+
+		DMLManager.updateAsUser(ctc);
 
 		// Since the InertDmlOperation does nothing, the DMLManager operation respectively does nothing,
 		// therefore the Contact is NOT saved within Salesforce.
-		System.assertEquals(0, actualContactList.size(), 'The Contact should not exist in Salesforce.');
+		query = 'select LastName from Contact where Id=\'' + ctc.Id + '\'';
+		actualContactList = Database.query(query);
+		System.assertNotEquals(ctc.LastName, actualContactList.get(0).LastName, 'The Contact should retain the original data.');
 	}
 
 	private class InertDmlOperations implements DMLManager.IDML {

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -491,7 +491,48 @@ private class Test_DMLManager {
 			//expected
 			System.assert(dmle.getMessage().contains('An existing record could not be found'));
 		}
-	} 
+	}
+
+	@IsTest
+	static void dmlOperation_When_CustomInertDmlOperationsAreSpecified_Expect_NoChangesWithinServer() {
+
+		Contact ctc = new Contact();
+		ctc.FirstName = 'Jeremiah';
+		ctc.LastName = 'Matthews';
+
+		DMLManager.dmlOperations = new InertDmlOperations();
+
+		DMLManager.insertAsUser(ctc);
+
+		String query = 'select Id from Contact where FirstName=\'' + ctc.FirstName + '\' and LastName=\'' + ctc.LastName + '\'';
+		List<Contact> actualContactList = Database.query(query);
+
+		// Since the InertDmlOperation does nothing, the DMLManager operation respectively does nothing,
+		// therefore the Contact is NOT saved within Salesforce.
+		System.assertEquals(0, actualContactList.size(), 'The Contact should not exist in Salesforce.');
+	}
+
+	private class InertDmlOperations implements DMLManager.IDML {
+		public List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete) {
+			return null;
+		}
+
+		public List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert) {
+			return null;
+		}
+
+		public List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords) {
+			return null;
+		}
+
+		public List<Database.SaveResult> updateOperation(List<SObject> recordsToUpdate) {
+			return null;
+		}
+
+		public List<Database.UpsertResult> upsertOperation(List<SObject> recordsToUpsert) {
+			return null;
+		}
+	}
 
 	private static void assignObjectPermission(User u, String objectType, Boolean create, Boolean edit, Boolean remove){
       	PermissionSet ps = new PermissionSet(Name = 'Enable' + objectType, Label = 'Enable ' + objectType);

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -503,44 +503,42 @@ private class Test_DMLManager {
 		// ------ First let's clearly assert the default DML operation is working ------
 		DMLManager.insertAsUser(ctc);
 		
-		String query = 'select Id from Contact where FirstName=\'' + ctc.FirstName + '\' and LastName=\'' + ctc.LastName + '\'';
-		List<Contact> actualContactList = Database.query(query);
+		List<Contact> actualContactList = [select Id from Contact where FirstName= :ctc.FirstName and LastName= :ctc.LastName];
 		System.assertEquals(1, actualContactList.size(), 'The Salesforce database should contain the new Contact.');
 
 		// ------ Now let's test the DML Operation injection ------
 		ctc.LastName = 'Long';
 
 		// Injecting the inert DML class
-		DMLManager.dmlOperations = new InertDmlOperations();
+		DMLManager.setDmlImplementation(new InertDML());
 
 		DMLManager.updateAsUser(ctc);
 
-		// Since the InertDmlOperation does nothing, the DMLManager operation respectively does nothing,
+		// Since the InertDml does nothing, the DMLManager operation respectively does nothing,
 		// therefore the Contact is NOT saved within Salesforce.
-		query = 'select LastName from Contact where Id=\'' + ctc.Id + '\'';
-		actualContactList = Database.query(query);
+		actualContactList = [select LastName from Contact where Id= :ctc.Id];
 		System.assertNotEquals(ctc.LastName, actualContactList.get(0).LastName, 'The Contact should retain the original data.');
 	}
 
-	private class InertDmlOperations implements DMLManager.IDML {
-		public List<Database.DeleteResult> deleteOperation(List<SObject> recordsToDelete) {
-			return null;
+	private class InertDml extends DMLManager.SimpleDML {
+		public override void dmlDelete(List<SObject> recordsToDelete) {
+			// Do nothing.
 		}
 
-		public List<Database.SaveResult> insertOperation(List<SObject> recordsToInsert) {
-			return null;
+		public override void dmlInsert(List<SObject> recordsToInsert) {
+			// Do nothing.
 		}
 
-		public List<Database.MergeResult> mergeOperation(sObject masterRecord, List<SObject> duplicateRecords) {
-			return null;
+		public override void dmlMerge(sObject masterRecord, List<SObject> duplicateRecords) {
+			// Do nothing.
 		}
 
-		public List<Database.SaveResult> updateOperation(List<SObject> recordsToUpdate) {
-			return null;
+		public override void dmlUpdate(List<SObject> recordsToUpdate) {
+			// Do nothing.
 		}
 
-		public List<Database.UpsertResult> upsertOperation(List<SObject> recordsToUpsert) {
-			return null;
+		public override void dmlUpsert(List<SObject> recordsToUpsert) {
+			// Do nothing.
 		}
 	}
 

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -175,6 +175,34 @@ private class Test_DMLManager {
 	
 	}
 	
+	@IsTest
+	static void mergeAsSystem_When_PassingASingleSObject_Expect_Success() {
+		// Insert a master account and two merge accounts
+		List<Account> accList = new List<Account>{
+			new Account(Name = 'Master Account'),
+			new Account(Name = 'Merge One')
+		};
+		
+		User restrictedUser = getRestrictedUser();
+		
+		System.runAs(restrictedUser){
+			insert accList;
+			
+			Account masterAcct = [SELECT Id, Name FROM Account WHERE Name = 'Master Account'];
+			List<Account> mergeList = [SELECT Id, Name FROM Account WHERE Name LIKE 'Merge%'];
+			System.assertEquals(1, mergeList.size());
+			
+			DMLManager.mergeAsSystem(masterAcct, mergeList.get(0));
+		}
+		
+		// Make sure 'Master Account' is still there.
+		Account masterAcct = [SELECT Id FROM Account WHERE Name = 'Master Account'];
+		
+		//Make sure merge accounts are gone
+		List<Account> mergeList = [SELECT Id FROM Account WHERE Name LIKE 'Merge%'];
+		System.assertEquals(0, mergeList.size());
+	}
+	
 	static testMethod void flsRestrictedInsert(){
 		Campaign c1 = new Campaign(Name = 'Test1 Campaign');
 		System.runAs(new User(Id = UserInfo.getUserId())){
@@ -499,6 +527,7 @@ private class Test_DMLManager {
 		Contact ctc = new Contact();
 		ctc.FirstName = 'Jeremiah';
 		ctc.LastName = 'Matthews';
+		String expectedLastName = ctc.LastName;
 
 		// ------ First let's clearly assert the default DML operation is working ------
 		DMLManager.insertAsUser(ctc);
@@ -517,7 +546,7 @@ private class Test_DMLManager {
 		// Since the InertDml does nothing, the DMLManager operation respectively does nothing,
 		// therefore the Contact is NOT saved within Salesforce.
 		actualContactList = [select LastName from Contact where Id= :ctc.Id];
-		System.assertNotEquals(ctc.LastName, actualContactList.get(0).LastName, 'The Contact should retain the original data.');
+		System.assertEquals(expectedLastName, actualContactList.get(0).LastName, 'The Contact should retain the original data.');
 	}
 
 	private class InertDml extends DMLManager.SimpleDML {


### PR DESCRIPTION
The primary need this change addresses is the facilitation of mock testing.  Consumers may test Database-interactive methods with in-memory SObjects while avoiding actual DML operations -- updating a non-existent SObject would cause a DMLException.

For those repo users that MAY NOT need this functionality, the change is fully backward compatible, allowing deployment without changing existing implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patronmanager/apex-dml-manager/11)
<!-- Reviewable:end -->
