### PR TITLE
Improve to allow unlocked packaging

### DIFF
--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -23,7 +23,7 @@
 *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
-public class DMLManager {
+public without sharing class DMLManager {
 	// Items in the following set must be entered in lower case
 	private static Set<String> exceptionValues = new Set<String> {'id','isdeleted','createddate','systemmodstamp','lastmodifiedbyid','createdbyid','lastmodifieddate'};
 

--- a/src/classes/DMLManager.cls
+++ b/src/classes/DMLManager.cls
@@ -23,7 +23,7 @@
 *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
-public inherited sharing class DMLManager {
+public class DMLManager {
 	// Items in the following set must be entered in lower case
 	private static Set<String> exceptionValues = new Set<String> {'id','isdeleted','createddate','systemmodstamp','lastmodifiedbyid','createdbyid','lastmodifieddate'};
 

--- a/src/classes/Test_DMLManager.cls
+++ b/src/classes/Test_DMLManager.cls
@@ -111,9 +111,10 @@ private class Test_DMLManager {
 		System.runAs(restrictedUser){
 			a1.Name = 'Apple Updated';
 			DMLManager.updateAsSystem(new Account[]{a1});
-			Account a1Reload = [SELECT Name FROM Account WHERE Id = :a1.Id];
-			System.assertEquals('Apple Updated', a1Reload.Name);
 		}
+		
+		Account a1Reload = [SELECT Name FROM Account WHERE Id = :a1.Id];
+		System.assertEquals('Apple Updated', a1Reload.Name);
 	}
 	
 	static testMethod void systemUpsert(){
@@ -129,9 +130,10 @@ private class Test_DMLManager {
 		
 		System.runAs(restrictedUser){
 			DMLManager.upsertAsSystem(new Account[]{a1Clone});
-			Account a1Reload = [SELECT Name FROM Account WHERE Id = :a1.Id];
-			System.assertEquals('Apple Updated', a1Reload.Name);
 		}
+		
+		Account a1Reload = [SELECT Name FROM Account WHERE Id = :a1.Id];
+		System.assertEquals('Apple Updated', a1Reload.Name);
 	}
 
 	static testMethod void systemDelete(){


### PR DESCRIPTION
DMLManager.cls:

On 28 May 2020 on this commit ef2b86d, omitted sharing declaration was replaced by inherited sharing. Due to this, if the user has not enough record level permissions, updateAsUser and upserAsUser can fail due to getExistingRecords not returning any record. Since this library is aimed for under the good purposes, it should execute regardless of user record level access, since it aimed to check only CRUD and FLS permissions on DML. This was mainly resulting in an error when running tests for trying to create an unlocked package of this library.

Test_DMLManager.cls
Moved query + assert for systemUpdate and systemUpsert since query was not returning SOQL rows under rusAs(restrictedUser) during unlocked package version creation running tests
